### PR TITLE
Fix column propagation query and improve heatmap layout

### DIFF
--- a/notebooks/03-column-propagation.ipynb
+++ b/notebooks/03-column-propagation.ipynb
@@ -1,203 +1,106 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": "Analysis of data column propagation timing across the 128 column subnets in PeerDAS."
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "tags": [
-          "parameters"
-        ]
-      },
-      "source": [
-        "target_date = None  # Set via papermill, or auto-detect from manifest"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "source": [
-        "import numpy as np\n",
-        "import plotly.graph_objects as go\n",
-        "\n",
-        "from loaders import load_parquet\n",
-        "\n",
-        "# Number of data columns in PeerDAS\n",
-        "NUM_COLUMNS = 128"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "source": [
-        "# Load column propagation data\n",
-        "df_col_first_seen = load_parquet(\"col_first_seen\", target_date)\n",
-        "\n",
-        "print(f\"Slots with column data: {len(df_col_first_seen)}\")"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Column first seen\n",
-        "\n",
-        "Heatmap showing when each of the 128 data columns was first observed, measured in milliseconds from slot start. Consistent patterns across columns indicate healthy propagation; outliers may signal network issues."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "source": [
-        "# Panel 1: Column first seen (ms into slot start) - 128 columns heatmap\n",
-        "\n",
-        "# Reshape for heatmap: rows = columns (c0-c127), columns = time\n",
-        "col_names = [f\"c{i}\" for i in range(NUM_COLUMNS)]\n",
-        "df_cols = df_col_first_seen[col_names].T\n",
-        "df_cols.columns = df_col_first_seen[\"time\"]\n",
-        "\n",
-        "fig = go.Figure(\n",
-        "    data=go.Heatmap(\n",
-        "        z=df_cols.values,\n",
-        "        x=df_cols.columns,\n",
-        "        y=[str(i) for i in range(NUM_COLUMNS)],\n",
-        "        zmin=1500,\n",
-        "        zmax=4000,\n",
-        "        colorbar=dict(title=\"ms\"),\n",
-        "    )\n",
-        ")\n",
-        "fig.update_layout(\n",
-        "    title=\"Column first seen (ms into slot start)\",\n",
-        "    xaxis_title=\"Slot Start Time\",\n",
-        "    yaxis_title=\"Column Index\",\n",
-        "    yaxis=dict(autorange=\"reversed\"),\n",
-        "    height=800,\n",
-        ")\n",
-        "fig.show()"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Delta from fastest column (intraslot, ms)\n",
-        "\n",
-        "Shows how much slower each column arrived compared to the fastest column in that slot. Highlights columns that consistently lag behind, which may indicate propagation bottlenecks."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "source": [
-        "# Compute delta from min value per slot for each column\n",
-        "col_names = [f\"c{i}\" for i in range(NUM_COLUMNS)]\n",
-        "df_delta = df_col_first_seen.copy()\n",
-        "\n",
-        "# Calculate row-wise minimum and subtract from each column\n",
-        "row_mins = df_delta[col_names].min(axis=1)\n",
-        "for col in col_names:\n",
-        "    df_delta[col] = df_delta[col] - row_mins\n",
-        "\n",
-        "# Reshape for heatmap\n",
-        "df_delta_cols = df_delta[col_names].T\n",
-        "df_delta_cols.columns = df_delta[\"time\"]\n",
-        "\n",
-        "fig = go.Figure(\n",
-        "    data=go.Heatmap(\n",
-        "        z=df_delta_cols.values,\n",
-        "        x=df_delta_cols.columns,\n",
-        "        y=[str(i) for i in range(NUM_COLUMNS)],\n",
-        "        colorscale=\"Inferno\",\n",
-        "        reversescale=False,\n",
-        "        zmin=0,\n",
-        "        zmax=250,\n",
-        "        colorbar=dict(title=\"ms\"),\n",
-        "    )\n",
-        ")\n",
-        "fig.update_layout(\n",
-        "    title=\"Delta from fastest column (intraslot, ms)\",\n",
-        "    xaxis_title=\"Slot Start Time\",\n",
-        "    yaxis_title=\"Column Index\",\n",
-        "    yaxis=dict(autorange=\"reversed\"),\n",
-        "    height=800,\n",
-        ")\n",
-        "fig.show()"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Delta normalized (0-1)\n",
-        "\n",
-        "Same delta data normalized to a 0\u20131 scale per slot, making it easier to compare relative propagation order regardless of absolute timing. Columns closer to 0 arrived first; those near 1 arrived last."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "source": [
-        "# Normalize delta values to 0-1 range per slot\n",
-        "col_names = [f\"c{i}\" for i in range(NUM_COLUMNS)]\n",
-        "df_normalized = df_col_first_seen.copy()\n",
-        "\n",
-        "# Calculate row-wise min and max, then normalize\n",
-        "row_mins = df_normalized[col_names].min(axis=1)\n",
-        "row_maxs = df_normalized[col_names].max(axis=1)\n",
-        "row_ranges = row_maxs - row_mins\n",
-        "\n",
-        "for col in col_names:\n",
-        "    df_normalized[col] = (df_normalized[col] - row_mins) / row_ranges.replace(0, np.nan)\n",
-        "\n",
-        "# Reshape for heatmap\n",
-        "df_norm_cols = df_normalized[col_names].T\n",
-        "df_norm_cols.columns = df_normalized[\"time\"]\n",
-        "\n",
-        "fig = go.Figure(\n",
-        "    data=go.Heatmap(\n",
-        "        z=df_norm_cols.values,\n",
-        "        x=df_norm_cols.columns,\n",
-        "        y=[str(i) for i in range(NUM_COLUMNS)],\n",
-        "        colorscale=\"YlGnBu\",\n",
-        "        reversescale=True,\n",
-        "        zmin=0,\n",
-        "        zmax=1,\n",
-        "        colorbar=dict(title=\"Normalized\"),\n",
-        "    )\n",
-        ")\n",
-        "fig.update_layout(\n",
-        "    title=\"Delta normalized (0-1)\",\n",
-        "    xaxis_title=\"Slot Start Time\",\n",
-        "    yaxis_title=\"Column Index\",\n",
-        "    yaxis=dict(autorange=\"reversed\"),\n",
-        "    height=800,\n",
-        ")\n",
-        "fig.show()"
-      ],
-      "execution_count": null,
-      "outputs": []
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "Analysis of data column propagation timing across the 128 column subnets in PeerDAS."
   },
-  "nbformat": 4,
-  "nbformat_minor": 4
+  {
+   "cell_type": "code",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "source": [
+    "target_date = None  # Set via papermill, or auto-detect from manifest"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import numpy as np\n",
+    "import plotly.graph_objects as go\n",
+    "\n",
+    "from loaders import load_parquet\n",
+    "\n",
+    "# Number of data columns in PeerDAS\n",
+    "NUM_COLUMNS = 128"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Load column propagation data\n",
+    "df_col_first_seen = load_parquet(\"col_first_seen\", target_date)\n",
+    "\n",
+    "print(f\"Slots with column data: {len(df_col_first_seen)}\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Column first seen\n",
+    "\n",
+    "Heatmap showing when each of the 128 data columns was first observed, measured in milliseconds from slot start. Consistent patterns across columns indicate healthy propagation; outliers may signal network issues."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "# Panel 1: Column first seen (ms into slot start) - 128 columns heatmap\n\n# Reshape for heatmap: rows = columns (c0-c127), columns = time\ncol_names = [f\"c{i}\" for i in range(NUM_COLUMNS)]\ndf_cols = df_col_first_seen[col_names].T\ndf_cols.columns = df_col_first_seen[\"time\"]\n\nfig = go.Figure(\n    data=go.Heatmap(\n        z=df_cols.values,\n        x=df_cols.columns,\n        y=[str(i) for i in range(NUM_COLUMNS)],\n        zmin=1500,\n        zmax=4000,\n        colorbar=dict(\n            title=\"ms\",\n            orientation=\"h\",\n            y=-0.15,\n            yanchor=\"top\",\n            x=0.5,\n            xanchor=\"center\",\n            len=0.8,\n        ),\n    )\n)\nfig.update_layout(\n    title=\"Column first seen (ms into slot start)\",\n    xaxis_title=\"Slot Start Time\",\n    yaxis_title=\"Column Index\",\n    yaxis=dict(autorange=\"reversed\"),\n    height=800,\n)\nfig.show()",
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Delta from fastest column (intraslot, ms)\n",
+    "\n",
+    "Shows how much slower each column arrived compared to the fastest column in that slot. Highlights columns that consistently lag behind, which may indicate propagation bottlenecks."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "# Compute delta from min value per slot for each column\ncol_names = [f\"c{i}\" for i in range(NUM_COLUMNS)]\ndf_delta = df_col_first_seen.copy()\n\n# Calculate row-wise minimum and subtract from each column\nrow_mins = df_delta[col_names].min(axis=1)\nfor col in col_names:\n    df_delta[col] = df_delta[col] - row_mins\n\n# Reshape for heatmap\ndf_delta_cols = df_delta[col_names].T\ndf_delta_cols.columns = df_delta[\"time\"]\n\nfig = go.Figure(\n    data=go.Heatmap(\n        z=df_delta_cols.values,\n        x=df_delta_cols.columns,\n        y=[str(i) for i in range(NUM_COLUMNS)],\n        colorscale=\"Inferno\",\n        reversescale=False,\n        zmin=0,\n        zmax=250,\n        colorbar=dict(\n            title=\"ms\",\n            orientation=\"h\",\n            y=-0.15,\n            yanchor=\"top\",\n            x=0.5,\n            xanchor=\"center\",\n            len=0.8,\n        ),\n    )\n)\nfig.update_layout(\n    title=\"Delta from fastest column (intraslot, ms)\",\n    xaxis_title=\"Slot Start Time\",\n    yaxis_title=\"Column Index\",\n    yaxis=dict(autorange=\"reversed\"),\n    height=800,\n)\nfig.show()",
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Delta normalized (0-1)\n",
+    "\n",
+    "Same delta data normalized to a 0–1 scale per slot, making it easier to compare relative propagation order regardless of absolute timing. Columns closer to 0 arrived first; those near 1 arrived last."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "# Normalize delta values to 0-1 range per slot\ncol_names = [f\"c{i}\" for i in range(NUM_COLUMNS)]\ndf_normalized = df_col_first_seen.copy()\n\n# Calculate row-wise min and max, then normalize\nrow_mins = df_normalized[col_names].min(axis=1)\nrow_maxs = df_normalized[col_names].max(axis=1)\nrow_ranges = row_maxs - row_mins\n\nfor col in col_names:\n    df_normalized[col] = (df_normalized[col] - row_mins) / row_ranges.replace(0, np.nan)\n\n# Reshape for heatmap\ndf_norm_cols = df_normalized[col_names].T\ndf_norm_cols.columns = df_normalized[\"time\"]\n\nfig = go.Figure(\n    data=go.Heatmap(\n        z=df_norm_cols.values,\n        x=df_norm_cols.columns,\n        y=[str(i) for i in range(NUM_COLUMNS)],\n        colorscale=\"YlGnBu\",\n        reversescale=True,\n        zmin=0,\n        zmax=1,\n        colorbar=dict(\n            title=\"Normalized\",\n            orientation=\"h\",\n            y=-0.15,\n            yanchor=\"top\",\n            x=0.5,\n            xanchor=\"center\",\n            len=0.8,\n        ),\n    )\n)\nfig.update_layout(\n    title=\"Delta normalized (0-1)\",\n    xaxis_title=\"Slot Start Time\",\n    yaxis_title=\"Column Index\",\n    yaxis=dict(autorange=\"reversed\"),\n    height=800,\n)\nfig.show()",
+   "execution_count": null,
+   "outputs": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }

--- a/queries/column_propagation.py
+++ b/queries/column_propagation.py
@@ -26,7 +26,8 @@ def fetch_col_first_seen(
 
     Returns row count.
     """
-    date_filter = _get_date_filter(target_date)
+    event_date_filter = _get_date_filter(target_date, "event_date_time")
+    slot_date_filter = _get_date_filter(target_date, "slot_start_date_time")
 
     col_selects = ",\n    ".join(
         [f"minIf(propagation_slot_start_diff, column_index = {i}) AS c{i}" for i in range(num_columns)]
@@ -37,7 +38,8 @@ SELECT
     slot_start_date_time AS time,
     {col_selects}
 FROM libp2p_gossipsub_data_column_sidecar
-WHERE {date_filter}
+WHERE {event_date_filter}
+  AND {slot_date_filter}
   AND meta_network_name = '{network}'
 GROUP BY slot_start_date_time
 ORDER BY time


### PR DESCRIPTION
## Summary
- Add `slot_start_date_time` filter to column propagation query to exclude events whose slots fall outside the target date range (keeps existing `event_date_time` filter)
- Move colorbar/legend to bottom of all three heatmaps with horizontal layout for better visual balance

## Test plan
- [ ] Verify query returns correct data for a target date
- [ ] Render notebook and confirm colorbars appear horizontally at the bottom of each heatmap

🤖 Generated with [Claude Code](https://claude.com/claude-code)