### PR TITLE
fix: serve HTML with no-cache to ensure manifest updates are seen

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -296,11 +296,13 @@ r2-bucket/
     └── pr-14.json            # PR preview manifest
 ```
 
-**Request flow:**
-1. Worker receives request to `observatory.ethp2p.dev/page`
-2. Loads `manifests/main.json` (cached 60s)
-3. Resolves `/page` → blob hash
-4. Serves `blobs/{hash}.html` with immutable caching
+**Serving logic:**
+1. Worker receives request for a path (e.g., `/`)
+2. Loads `manifests/main.json` (cached 60s in worker)
+3. Resolves path → blob key (e.g., `blobs/abc.html`)
+4. Serves blob with appropriate headers:
+   - **HTML**: `Cache-Control: public, max-age=0, must-revalidate` (Browser always checks for manifest updates)
+   - **Assets**: `Cache-Control: public, max-age=31536000, immutable` (Permanent cache for content-addressed files)
 
 **Domains:**
 - Production: `observatory.ethp2p.dev`


### PR DESCRIPTION
## Summary
Fixed the issue where deployments required a hard refresh to be visible in the browser.

## Problem
Currently, all files (including the resolved HTML pages) are served with \`Cache-Control: public, max-age=31536000, immutable\`. Since the URL for pages (like \`/\`) remains the same but the underlying blob changes after a deployment, browsers were serving the stale cached HTML and never revalidating.

## Changes
- Updated the Cloudflare Worker to serve **HTML files** with \`Cache-Control: public, max-age=0, must-revalidate\`.
- Continued serving **Static Assets** (JS, CSS, images) with the immutable flag as their URLs are content-addressed.
- Updated \`GEMINI.md\` to document this caching strategy.