### PR TITLE
feat: add mempool visibility analysis notebook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ notebooks/data/
 .DS_Store
 
 node_modules/
+
+# Continuous Claude cache (local only)
+.claude/cache/

--- a/notebooks/04-mempool-visibility.ipynb
+++ b/notebooks/04-mempool-visibility.ipynb
@@ -1,0 +1,202 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Analysis of transaction visibility in the public mempool before block inclusion on Ethereum mainnet."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": "import pandas as pd\nimport plotly.express as px\nimport plotly.graph_objects as go\n\nfrom loaders import load_parquet, display_sql\n\n# Transaction type labels\nTX_TYPE_LABELS = {\n    0: \"Legacy\",\n    1: \"Access list\",\n    2: \"EIP-1559\",\n    3: \"Blob\",\n    4: \"EIP-7702\",\n}\n\nTX_TYPE_COLORS = {\n    0: \"#636EFA\",\n    1: \"#EF553B\",\n    2: \"#00CC96\",\n    3: \"#AB63FA\",\n    4: \"#FFA15A\",\n}\n\ntarget_date = None  # Set via papermill, or auto-detect from manifest"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "sql-fold"
+    ]
+   },
+   "outputs": [],
+   "source": "display_sql(\"mempool_coverage\", target_date)"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "df = load_parquet(\"mempool_coverage\", target_date)\ndf[\"tx_type_label\"] = df[\"tx_type\"].map(TX_TYPE_LABELS)\ndf[\"coverage_pct\"] = df[\"seen_in_mempool\"] / df[\"total_txs\"] * 100\n\nprint(f\"Loaded {len(df):,} hour/type rows\")\nprint(f\"Hours: {df['hour'].nunique():,}\")\nprint(f\"Total transactions: {df['total_txs'].sum():,}\")"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Coverage by transaction type\n",
+    "\n",
+    "Summary of how many transactions were seen in the public mempool before block inclusion. Low coverage indicates private or MEV transactions that bypass the public mempool."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Aggregate by type\n",
+    "df_summary = df.groupby([\"tx_type\", \"tx_type_label\"]).agg({\n",
+    "    \"total_txs\": \"sum\",\n",
+    "    \"seen_in_mempool\": \"sum\",\n",
+    "}).reset_index()\n",
+    "df_summary[\"coverage_pct\"] = df_summary[\"seen_in_mempool\"] / df_summary[\"total_txs\"] * 100\n",
+    "\n",
+    "# Display summary table\n",
+    "summary_display = df_summary[[\"tx_type_label\", \"total_txs\", \"seen_in_mempool\", \"coverage_pct\"]].copy()\n",
+    "summary_display.columns = [\"Type\", \"Total\", \"Seen\", \"Coverage %\"]\n",
+    "summary_display[\"Coverage %\"] = summary_display[\"Coverage %\"].round(1)\n",
+    "summary_display"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Coverage bar chart\n",
+    "fig = px.bar(\n",
+    "    df_summary,\n",
+    "    x=\"tx_type_label\",\n",
+    "    y=\"coverage_pct\",\n",
+    "    color=\"tx_type\",\n",
+    "    color_discrete_map=TX_TYPE_COLORS,\n",
+    "    labels={\"tx_type_label\": \"Transaction type\", \"coverage_pct\": \"Mempool visibility (%)\"},\n",
+    "    text=\"coverage_pct\",\n",
+    ")\n",
+    "fig.update_traces(texttemplate=\"%{text:.1f}%\", textposition=\"outside\", showlegend=False)\n",
+    "fig.update_layout(\n",
+    "    margin=dict(l=60, r=30, t=30, b=60),\n",
+    "    yaxis=dict(range=[0, 105]),\n",
+    "    height=400,\n",
+    ")\n",
+    "fig.show(config={\"responsive\": True})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Hourly coverage trends\n",
+    "\n",
+    "Mempool visibility percentage over time for each transaction type. Blob transactions (type 3) typically have the highest visibility since they propagate through the public network."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Data is already hourly from the query\nfig = px.line(\n    df,\n    x=\"hour\",\n    y=\"coverage_pct\",\n    color=\"tx_type_label\",\n    color_discrete_map={v: TX_TYPE_COLORS[k] for k, v in TX_TYPE_LABELS.items()},\n    labels={\"hour\": \"Time\", \"coverage_pct\": \"Mempool visibility (%)\", \"tx_type_label\": \"Type\"},\n    markers=True,\n)\nfig.update_layout(\n    margin=dict(l=60, r=30, t=30, b=60),\n    legend=dict(orientation=\"h\", yanchor=\"bottom\", y=1.02, xanchor=\"left\", x=0),\n    height=400,\n)\nfig.show(config={\"responsive\": True})"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Transaction volume over time\n",
+    "\n",
+    "Hourly transaction counts split by public (seen in mempool) vs private (not seen). The private portion represents MEV bundles and other transactions submitted directly to builders."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Aggregate across types by hour (already hourly data)\ndf_volume = df.groupby(\"hour\").agg({\n    \"total_txs\": \"sum\",\n    \"seen_in_mempool\": \"sum\",\n}).reset_index()\ndf_volume[\"private_txs\"] = df_volume[\"total_txs\"] - df_volume[\"seen_in_mempool\"]\n\nfig = go.Figure()\nfig.add_trace(go.Bar(\n    x=df_volume[\"hour\"],\n    y=df_volume[\"seen_in_mempool\"],\n    name=\"Public (seen in mempool)\",\n    marker_color=\"#3498db\",\n))\nfig.add_trace(go.Bar(\n    x=df_volume[\"hour\"],\n    y=df_volume[\"private_txs\"],\n    name=\"Private (not seen)\",\n    marker_color=\"#95a5a6\",\n))\nfig.update_layout(\n    barmode=\"stack\",\n    margin=dict(l=60, r=30, t=30, b=60),\n    xaxis=dict(title=\"Time\"),\n    yaxis=dict(title=\"Transaction count\"),\n    legend=dict(orientation=\"h\", yanchor=\"bottom\", y=1.02, xanchor=\"left\", x=0),\n    height=400,\n)\nfig.show(config={\"responsive\": True})"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Coverage heatmap\n\nHeatmap showing mempool visibility over time for each transaction type. Darker colors indicate higher coverage (more transactions seen in the public mempool)."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Pivot for heatmap using hourly data directly\ndf_pivot = df.pivot(index=\"tx_type_label\", columns=\"hour\", values=\"coverage_pct\").fillna(0)\n\nfig = go.Figure(\n    data=go.Heatmap(\n        z=df_pivot.values,\n        x=df_pivot.columns,\n        y=df_pivot.index,\n        colorscale=\"Greens\",\n        colorbar=dict(title=dict(text=\"Coverage %\", side=\"right\")),\n    )\n)\nfig.update_layout(\n    margin=dict(l=100, r=30, t=30, b=60),\n    xaxis=dict(title=\"Time\"),\n    yaxis=dict(title=\"Transaction type\"),\n    height=300,\n)\nfig.show(config={\"responsive\": True})"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Sentry coverage\n",
+    "\n",
+    "How much of the canonical transaction set each mempool observer (sentry) captured. Higher coverage indicates better mempool visibility from that observation point."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "sql-fold"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "display_sql(\"sentry_coverage\", target_date)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_sentry = load_parquet(\"sentry_coverage\", target_date)\n",
+    "\n",
+    "# Shorten sentry names for display\n",
+    "df_sentry[\"sentry_short\"] = df_sentry[\"sentry\"].str.replace(\"ethpandaops/mainnet/\", \"\")\n",
+    "\n",
+    "fig = px.bar(\n",
+    "    df_sentry.head(15),\n",
+    "    x=\"coverage_pct\",\n",
+    "    y=\"sentry_short\",\n",
+    "    orientation=\"h\",\n",
+    "    labels={\"coverage_pct\": \"Coverage (%)\", \"sentry_short\": \"Sentry\"},\n",
+    "    text=\"coverage_pct\",\n",
+    ")\n",
+    "fig.update_traces(texttemplate=\"%{text:.1f}%\", textposition=\"outside\")\n",
+    "fig.update_layout(\n",
+    "    margin=dict(l=250, r=60, t=30, b=60),\n",
+    "    xaxis=dict(range=[0, 105]),\n",
+    "    yaxis=dict(autorange=\"reversed\"),\n",
+    "    height=500,\n",
+    ")\n",
+    "fig.show(config={\"responsive\": True})"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -70,6 +70,24 @@ queries:
     description: Column first seen timing across 128 subnets
     output_file: col_first_seen.parquet
 
+  tx_per_slot:
+    module: queries.mempool_visibility
+    function: fetch_tx_per_slot
+    description: Transaction counts per slot per type
+    output_file: tx_per_slot.parquet
+
+  mempool_coverage:
+    module: queries.mempool_visibility
+    function: fetch_mempool_coverage
+    description: Hourly mempool coverage and wait time stats
+    output_file: mempool_coverage.parquet
+
+  sentry_coverage:
+    module: queries.mempool_visibility
+    function: fetch_sentry_coverage
+    description: Per-sentry mempool coverage rates
+    output_file: sentry_coverage.parquet
+
 # ============================================
 # Notebook Registry
 # ============================================
@@ -118,6 +136,22 @@ notebooks:
         type: date
         required: true
     order: 3
+
+  - id: mempool-visibility
+    title: Mempool Visibility
+    description: Transaction visibility in the public mempool before block inclusion
+    icon: Eye
+    source: notebooks/04-mempool-visibility.ipynb
+    schedule: daily
+    queries:
+      - tx_per_slot
+      - mempool_coverage
+      - sentry_coverage
+    parameters:
+      - name: target_date
+        type: date
+        required: true
+    order: 4
 
 # Schedule options: hourly, daily, weekly, manual
 # - hourly: Runs every hour, accumulating data throughout the day

--- a/queries/mempool_visibility.py
+++ b/queries/mempool_visibility.py
@@ -1,0 +1,115 @@
+"""
+Fetch functions for mempool visibility analysis.
+
+Analyzes transaction visibility in the public mempool before block inclusion.
+"""
+
+
+def _get_date_filter(target_date: str, column: str = "slot_start_date_time") -> str:
+    """Generate SQL date filter for a specific date."""
+    return f"{column} >= '{target_date}' AND {column} < '{target_date}'::date + INTERVAL 1 DAY"
+
+
+def fetch_tx_per_slot(
+    client,
+    target_date: str,
+    network: str = "mainnet",
+) -> tuple:
+    """Fetch transaction counts per slot per type.
+
+    Fast query - no mempool join.
+
+    Returns (df, query).
+    """
+    date_filter = _get_date_filter(target_date)
+
+    query = f"""
+SELECT
+    slot,
+    slot_start_date_time,
+    type AS tx_type,
+    count() AS total_txs
+FROM canonical_beacon_block_execution_transaction
+WHERE meta_network_name = '{network}'
+  AND {date_filter}
+GROUP BY slot, slot_start_date_time, type
+ORDER BY slot, type
+"""
+
+    df = client.query_df(query)
+    return df, query
+
+
+def fetch_mempool_coverage(
+    client,
+    target_date: str,
+    network: str = "mainnet",
+) -> tuple:
+    """Fetch hourly mempool coverage stats.
+
+    Uses GLOBAL IN semi-join for performance.
+    Returns coverage counts per hour per type.
+
+    Returns (df, query).
+    """
+    date_filter = _get_date_filter(target_date)
+
+    query = f"""
+SELECT
+    toStartOfHour(slot_start_date_time) AS hour,
+    type AS tx_type,
+    count() AS total_txs,
+    countIf(hash GLOBAL IN (
+        SELECT DISTINCT hash
+        FROM mempool_transaction
+        WHERE meta_network_name = '{network}'
+          AND event_date_time >= '{target_date}'::date - INTERVAL 1 HOUR
+          AND event_date_time < '{target_date}'::date + INTERVAL 1 DAY
+    )) AS seen_in_mempool
+FROM canonical_beacon_block_execution_transaction
+WHERE meta_network_name = '{network}'
+  AND {date_filter}
+GROUP BY hour, tx_type
+ORDER BY hour, tx_type
+"""
+
+    df = client.query_df(query)
+    return df, query
+
+
+def fetch_sentry_coverage(
+    client,
+    target_date: str,
+    network: str = "mainnet",
+) -> tuple:
+    """Fetch per-sentry coverage rates.
+
+    Returns (df, query).
+    """
+    date_filter = _get_date_filter(target_date)
+
+    query = f"""
+WITH canonical_hashes AS (
+    SELECT DISTINCT hash
+    FROM canonical_beacon_block_execution_transaction
+    WHERE meta_network_name = '{network}'
+      AND {date_filter}
+),
+total_canonical AS (
+    SELECT count() AS total FROM canonical_hashes
+)
+SELECT
+    meta_client_name AS sentry,
+    count(DISTINCT hash) AS txs_seen,
+    round(count(DISTINCT hash) * 100.0 / (SELECT total FROM total_canonical), 2) AS coverage_pct
+FROM mempool_transaction
+WHERE meta_network_name = '{network}'
+  AND event_date_time >= '{target_date}'::date - INTERVAL 1 HOUR
+  AND event_date_time < '{target_date}'::date + INTERVAL 1 DAY
+  AND hash GLOBAL IN (SELECT hash FROM canonical_hashes)
+GROUP BY meta_client_name
+ORDER BY txs_seen DESC
+"""
+
+    df = client.query_df(query)
+    return df, query


### PR DESCRIPTION
## Summary

- Add new notebook analyzing transaction visibility in the public mempool before block inclusion
- Implement optimized ClickHouse queries using `GLOBAL IN` semi-join pattern for distributed tables
- Register queries and notebook in pipeline configuration

## Queries

| Query | Description |
|-------|-------------|
| `tx_per_slot` | Per-slot transaction counts by type (fast, no mempool join) |
| `mempool_coverage` | Hourly coverage rates using semi-join pattern |
| `sentry_coverage` | Per-sentry observation rates |

## Visualizations

- Coverage by transaction type (bar chart + summary table)
- Hourly coverage trends (line chart)
- Public vs private transaction volume (stacked bar)
- Coverage heatmap by hour and type
- Sentry coverage comparison (horizontal bar)

## Test plan

- [ ] Run `just fetch` to verify queries execute without timeout
- [ ] Run `just render` to verify notebook renders correctly
- [ ] Check visualizations display properly in rendered HTML