### PR TITLE
fix: reduce aggressive Cloudflare caching

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -233,10 +233,11 @@ async function serveBlob(
   );
 
   // Cache control:
-  // - HTML files: Always revalidate to ensure manifest updates are seen immediately
+  // - HTML files: Browser revalidates with CDN, CDN caches 60s then revalidates with Worker
   // - Other files (assets): Immutable caching since their URLs are content-addressed
   if (contentType.includes("text/html")) {
-    headers.set("Cache-Control", "public, max-age=0, must-revalidate");
+    headers.set("Cache-Control", "max-age=0, must-revalidate");
+    headers.set("CDN-Cache-Control", "max-age=60");
   } else {
     headers.set("Cache-Control", "public, max-age=31536000, immutable");
   }


### PR DESCRIPTION
## Summary

Use `CDN-Cache-Control` header to properly configure edge caching:

```typescript
// Browser: always revalidate with CDN
headers.set("Cache-Control", "max-age=0, must-revalidate");
// CDN: cache 60s then revalidate with Worker  
headers.set("CDN-Cache-Control", "max-age=60");
```

## How it works

1. **Browser** always checks with CDN edge (fast, nearby)
2. **CDN** serves cached response for 60 seconds
3. After 60s, CDN revalidates with Worker using ETag
4. If content unchanged: 304 (fast), if changed: new content

## Benefits

- CDN caching enabled for performance
- Updates propagate within 60 seconds
- No external dependencies (no API tokens, no cache purge calls)
- ETag-based revalidation keeps it efficient

Fixes #28