### PR TITLE
fix: disable ClickHouse session ID to prevent locking errors in CI

### DIFF
--- a/scripts/fetch_data.py
+++ b/scripts/fetch_data.py
@@ -289,12 +289,15 @@ def main() -> None:
         return
 
     # Create ClickHouse client
+    # Disable session ID to avoid "session is locked" errors when CI runs are cancelled
+    # and restarted - sessions can remain locked server-side for a short period
     client = clickhouse_connect.get_client(
         host=os.environ["CLICKHOUSE_HOST"],
         port=int(os.environ.get("CLICKHOUSE_PORT", 8443)),
         username=os.environ["CLICKHOUSE_USER"],
         password=os.environ["CLICKHOUSE_PASSWORD"],
         secure=True,
+        autogenerate_session_id=False,
     )
 
     output_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
The clickhouse-connect library auto-generates a session ID by default, which persists across all queries from the same client. When CI runs are cancelled mid-query and restarted, ClickHouse may still hold that session as locked, causing "Session is locked by a concurrent client" errors.

Setting `autogenerate_session_id=False` disables session usage entirely, which is appropriate for this stateless batch fetching use case.