### PR TITLE
ci: deploy worker to Cloudflare when changed

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -204,6 +204,24 @@ jobs:
             --dist site/dist \
             --manifest "${{ steps.manifest.outputs.name }}"
 
+      # ============================================
+      # Deploy Worker (if changed)
+      # ============================================
+      - name: Check if worker changed
+        id: worker-check
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            worker:
+              - 'worker/**'
+
+      - name: Deploy worker
+        if: (steps.worker-check.outputs.worker == 'true' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.WORKERS_API_TOKEN }}
+          workingDirectory: worker
+
       - name: Comment preview URL on PR
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v7


### PR DESCRIPTION
## Summary

- Adds worker deployment step to CI using `cloudflare/wrangler-action@v3`
- Deploys when worker files change on push to main
- Manual workflow dispatch always deploys worker

## Problem

The worker caching fix from commit 1d09fa3 was never deployed. The CI only uploads site content to R2, not the worker itself. This caused HTML pages to be served with aggressive caching (`max-age=31536000, immutable`) instead of the correct headers (`max-age=0, must-revalidate`).

## Test plan

- [x] Add `WORKERS_API_TOKEN` secret to repo
- [x] Merge and trigger workflow dispatch to deploy worker
- [x] Verify HTML responses have correct cache headers