### PR TITLE
fix: add kernel death to retry conditions in render script

### DIFF
--- a/scripts/render_notebooks.py
+++ b/scripts/render_notebooks.py
@@ -229,11 +229,12 @@ def render_notebook(
                 except Exception as e:
                     last_error = e
                     error_str = str(e)
-                    # Retry on kernel/ZMQ errors
+                    # Retry on kernel/ZMQ errors (common in parallel execution)
                     if attempt < max_retries - 1 and (
                         "ZMQError" in error_str
                         or "Address already in use" in error_str
                         or "Kernel didn't respond" in error_str
+                        or "Kernel died" in error_str
                     ):
                         # Random backoff to desynchronize parallel retries
                         time.sleep(random.uniform(1, 3))


### PR DESCRIPTION
## Summary
- Add "Kernel died" error pattern to retry conditions in notebook rendering

## Problem
CI was failing on `2025-12-25/blob-inclusion` with error:
```
Kernel died before replying to kernel_info
```

This transient kernel failure during parallel notebook execution wasn't caught by the existing retry logic, which only handled:
- `ZMQError`
- `Address already in use`
- `Kernel didn't respond`

## Solution
Add `"Kernel died"` to the retry conditions so these transient failures are automatically retried with random backoff.

## Test plan
- [x] Python syntax verified
- [x] Local render test passed (script executes correctly)