### PR TITLE
feat(site): add network overview dashboard page

### DIFF
--- a/site/src/components/Icon.astro
+++ b/site/src/components/Icon.astro
@@ -1,5 +1,5 @@
 ---
-import { Activity, AlertCircle, AlertTriangle, Calendar, ChevronLeft, ChevronRight, Clock, Download, Eye, FileText, Gauge, Gavel, Grid3x3, Layers, Link, List, PanelLeft, Timer, XCircle } from 'lucide-react';
+import { Activity, AlertCircle, AlertTriangle, Calendar, ChevronLeft, ChevronRight, Clock, Download, Eye, FileText, Gauge, Gavel, Grid3x3, Layers, LayoutDashboard, Link, List, PanelLeft, Timer, XCircle } from 'lucide-react';
 
 interface Props {
   name: string;
@@ -27,6 +27,7 @@ const icons: Record<string, any> = {
   Gavel,
   Grid3x3,
   Layers,
+  LayoutDashboard,
   Link,
   List,
   PanelLeft,

--- a/site/src/components/OverviewContent.astro
+++ b/site/src/components/OverviewContent.astro
@@ -1,0 +1,455 @@
+---
+// src/components/OverviewContent.astro
+// Shared by /latest/overview and /[year]/[month]/[day]/overview
+import type { NotebookConfig } from '@/lib/data';
+import { getLatestDate } from '@/lib/data';
+
+interface Props {
+  date: string;        // YYYY-MM-DD
+  notebooks: NotebookConfig[];
+}
+
+const { date, notebooks } = Astro.props;
+const latestDate = getLatestDate();
+const isLatest = date === latestDate;
+
+function notebookUrl(id: string): string {
+  if (isLatest) return `/latest/${id}`;
+  const [y, m, d] = date.split('-');
+  return `/${y}/${m}/${d}/${id}`;
+}
+
+const groups = [
+  {
+    icon: '📦',
+    label: 'Blob / Data Availability',
+    ids: ['blob-inclusion', 'blob-flow', 'block-column-timing'],
+  },
+  {
+    icon: '📡',
+    label: 'Propagation',
+    ids: ['block-propagation-size', 'column-propagation', 'propagation-anomalies'],
+  },
+  {
+    icon: '⚡',
+    label: 'MEV & Mempool',
+    ids: ['mev-pipeline', 'mempool-visibility'],
+  },
+  {
+    icon: '🏥',
+    label: 'Network Health',
+    ids: ['missed-slots'],
+  },
+];
+
+const displayDate = new Date(date + 'T12:00:00Z').toLocaleDateString('en-US', {
+  weekday: 'long', year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC',
+});
+---
+
+<div class="overview-root">
+
+  <!-- Header -->
+  <div class="overview-header">
+    <div>
+      <h1 class="overview-title">Network Overview</h1>
+      <p class="overview-sub">{displayDate} · Mainnet</p>
+    </div>
+    {isLatest && (
+      <span class="live-badge">
+        <span class="live-dot" />
+        Latest
+      </span>
+    )}
+  </div>
+
+  <!-- Stat cards (values injected client-side from parquet) -->
+  <div class="stat-grid">
+
+    <div class="stat-card" id="card-blobs" data-color="neutral">
+      <div class="stat-label">Avg Blobs / Slot</div>
+      <div class="stat-value" id="val-blobs"><span class="skeleton">——</span></div>
+      <div class="stat-sub"  id="sub-blobs">loading…</div>
+      <a class="stat-drill"  href={notebookUrl('blob-inclusion')}>blob-inclusion →</a>
+    </div>
+
+    <div class="stat-card" id="card-missed" data-color="neutral">
+      <div class="stat-label">Missed Slots</div>
+      <div class="stat-value" id="val-missed"><span class="skeleton">——</span></div>
+      <div class="stat-sub"  id="sub-missed">loading…</div>
+      <a class="stat-drill"  href={notebookUrl('missed-slots')}>missed-slots →</a>
+    </div>
+
+    <div class="stat-card" id="card-mempool" data-color="neutral">
+      <div class="stat-label">Mempool Coverage</div>
+      <div class="stat-value" id="val-mempool"><span class="skeleton">——</span></div>
+      <div class="stat-sub"  id="sub-mempool">loading…</div>
+      <a class="stat-drill"  href={notebookUrl('mempool-visibility')}>mempool-visibility →</a>
+    </div>
+
+    <div class="stat-card" id="card-slots" data-color="neutral">
+      <div class="stat-label">Total Slots</div>
+      <div class="stat-value" id="val-slots"><span class="skeleton">——</span></div>
+      <div class="stat-sub"  id="sub-slots">loading…</div>
+      <a class="stat-drill"  href={notebookUrl('blob-inclusion')}>blob-inclusion →</a>
+    </div>
+
+  </div>
+
+  <!-- Notebook grid -->
+  <div class="section-label">Notebooks</div>
+  <div class="nb-grid">
+    {groups.map(group => {
+      const members = group.ids
+        .map(id => notebooks.find((nb: NotebookConfig) => nb.id === id))
+        .filter((nb): nb is NotebookConfig => nb !== undefined);
+      if (!members.length) return null;
+      return (
+        <div class="nb-group">
+          <div class="nb-group-header">
+            <span>{group.icon}</span>
+            <span class="nb-group-title">{group.label}</span>
+          </div>
+          <div class="nb-group-body">
+            {members.map((nb: NotebookConfig) => (
+              <a class="nb-row" href={notebookUrl(nb.id)}>
+                <div class="nb-row-info">
+                  <span class="nb-row-name">
+                    {nb.icon && <span class="nb-icon">{nb.icon}</span>}
+                    {nb.title}
+                  </span>
+                  <span class="nb-row-desc">{nb.description}</span>
+                </div>
+                <span class="nb-row-arrow">→</span>
+              </a>
+            ))}
+          </div>
+        </div>
+      );
+    })}
+  </div>
+
+</div>
+
+<!-- Client-side parquet fetch using hyparquet (pure JS, no WASM) -->
+<script define:vars={{ date }}>
+
+const DATA_BASE = '/data';
+
+/**
+ * Read columns from a parquet file using hyparquet.
+ * Returns an object mapping column names to arrays of values.
+ */
+async function readParquetColumns(date, filename, columns) {
+  const url = `${DATA_BASE}/${date}/${filename}`;
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`HTTP ${res.status}: ${url}`);
+  const buffer = await res.arrayBuffer();
+
+  const { parquetRead } = await import('https://esm.sh/hyparquet@1.7.1');
+
+  return new Promise((resolve, reject) => {
+    try {
+      parquetRead({
+        file: buffer,
+        columns,
+        onComplete: (rows) => {
+          // rows is an array of arrays (one per row)
+          // Convert to column-oriented format
+          const out = {};
+          for (let ci = 0; ci < columns.length; ci++) {
+            out[columns[ci]] = rows.map(row => row[ci]);
+          }
+          resolve(out);
+        },
+      });
+    } catch (e) {
+      reject(e);
+    }
+  });
+}
+
+function setVal(id, text) {
+  const el = document.getElementById(id);
+  if (el) el.innerHTML = text;
+}
+function setSub(id, text) {
+  const el = document.getElementById(`sub-${id}`);
+  if (el) el.textContent = text;
+}
+function setColor(id, color) {
+  const el = document.getElementById(`card-${id}`);
+  if (el) el.dataset.color = color;
+}
+
+async function loadBlobStats() {
+  try {
+    const data = await readParquetColumns(date, 'blobs_per_slot.parquet', ['blob_count']);
+    const counts  = data['blob_count'];
+    const total   = counts.length;
+    const missed  = counts.filter(v => v === 0 || v == null).length;
+    const active  = counts.filter(v => v > 0);
+    const avg     = active.length
+      ? (active.reduce((a, b) => a + Number(b), 0) / active.length).toFixed(2)
+      : '—';
+    const missRate = total ? ((missed / total) * 100).toFixed(1) : '—';
+
+    setVal('val-blobs', avg);
+    setSub('blobs', `${active.length.toLocaleString()} slots with blobs`);
+    setColor('blobs', parseFloat(avg) >= 3 ? 'green' : parseFloat(avg) >= 1 ? 'yellow' : 'red');
+
+    setVal('val-missed', missed.toLocaleString());
+    setSub('missed', `${missRate}% miss rate`);
+    setColor('missed', missed <= 5 ? 'green' : missed <= 20 ? 'yellow' : 'red');
+
+    setVal('val-slots', total.toLocaleString());
+    setSub('slots', `${date} · mainnet`);
+    setColor('slots', 'blue');
+
+  } catch (e) {
+    console.warn('[overview] blobs_per_slot failed:', e);
+    for (const id of ['blobs', 'missed', 'slots']) {
+      setVal(`val-${id}`, '—');
+      setSub(id, 'data unavailable');
+    }
+  }
+}
+
+async function loadMempoolStats() {
+  try {
+    // Try different possible column names
+    let data;
+    let col;
+    for (const colName of ['coverage_pct', 'visible_pct', 'coverage']) {
+      try {
+        data = await readParquetColumns(date, 'mempool_coverage.parquet', [colName]);
+        col = data[colName];
+        if (col && col.length > 0) break;
+      } catch { continue; }
+    }
+    if (!col || col.length === 0) throw new Error('no coverage column found');
+
+    const values = col.filter(v => v != null).map(Number);
+    const avg    = values.reduce((a, b) => a + b, 0) / values.length;
+    const pct    = (avg > 1 ? avg : avg * 100).toFixed(1);
+
+    setVal('val-mempool', `${pct}%`);
+    setSub('mempool', 'avg tx visibility pre-inclusion');
+    setColor('mempool',
+      parseFloat(pct) >= 70 ? 'green' :
+      parseFloat(pct) >= 40 ? 'yellow' : 'red'
+    );
+  } catch (e) {
+    console.warn('[overview] mempool_coverage failed:', e);
+    setVal('val-mempool', '—');
+    setSub('mempool', 'see notebook');
+  }
+}
+
+Promise.allSettled([loadBlobStats(), loadMempoolStats()]);
+
+</script>
+
+<style>
+.overview-root {
+  font-family: var(--font-sans, system-ui, sans-serif);
+}
+
+/* Header */
+.overview-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.75rem;
+}
+.overview-title {
+  font-size: 1.5rem;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  color: var(--foreground);
+}
+.overview-sub {
+  font-size: 0.8rem;
+  color: var(--muted-foreground);
+  margin-top: 0.25rem;
+  font-family: var(--font-mono, monospace);
+}
+.live-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.7rem;
+  font-family: var(--font-mono, monospace);
+  color: var(--muted-foreground);
+  background: var(--muted);
+  border-radius: 4px;
+  padding: 0.25rem 0.6rem;
+  white-space: nowrap;
+  margin-top: 4px;
+}
+.live-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #3fb950;
+  animation: blink 2s ease-in-out infinite;
+}
+@keyframes blink { 0%,100%{opacity:1} 50%{opacity:0.3} }
+
+/* Stat grid */
+.stat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 0.75rem;
+  margin-bottom: 2.5rem;
+}
+.stat-card {
+  border-radius: 8px;
+  padding: 1rem 1.25rem;
+  border: 1px solid var(--border);
+  background: var(--card, var(--background));
+  position: relative;
+  overflow: hidden;
+}
+.stat-card::before {
+  content: '';
+  position: absolute;
+  inset: 0 0 auto 0;
+  height: 2px;
+  border-radius: 8px 8px 0 0;
+  background: var(--border);
+  transition: background 0.3s;
+}
+.stat-card[data-color="green"]::before  { background: #3fb950; }
+.stat-card[data-color="yellow"]::before { background: #d29922; }
+.stat-card[data-color="red"]::before    { background: #f85149; }
+.stat-card[data-color="blue"]::before   { background: var(--primary, #58a6ff); }
+
+.stat-label {
+  font-size: 0.67rem;
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  color: var(--muted-foreground);
+  font-family: var(--font-mono, monospace);
+  margin-bottom: 0.5rem;
+}
+.stat-value {
+  font-size: 1.8rem;
+  font-weight: 500;
+  line-height: 1;
+  color: var(--foreground);
+  font-family: var(--font-mono, monospace);
+  margin-bottom: 0.3rem;
+  min-height: 1.8rem;
+}
+.skeleton {
+  color: var(--border);
+  animation: shimmer 1.4s ease-in-out infinite;
+}
+@keyframes shimmer { 0%,100%{opacity:.3} 50%{opacity:.8} }
+.stat-sub {
+  font-size: 0.72rem;
+  color: var(--muted-foreground);
+  font-family: var(--font-mono, monospace);
+  min-height: 1rem;
+}
+.stat-drill {
+  display: inline-block;
+  margin-top: 0.6rem;
+  font-size: 0.7rem;
+  font-family: var(--font-mono, monospace);
+  color: var(--primary, #58a6ff);
+  text-decoration: none;
+}
+.stat-drill:hover { text-decoration: underline; }
+
+/* Section label */
+.section-label {
+  font-size: 0.67rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--muted-foreground);
+  font-family: var(--font-mono, monospace);
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 1rem;
+}
+
+/* Notebook grid */
+.nb-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 1rem;
+}
+.nb-group {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+  background: var(--card, var(--background));
+}
+.nb-group-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 1rem;
+  border-bottom: 1px solid var(--border);
+  background: var(--muted);
+}
+.nb-group-title {
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted-foreground);
+  font-family: var(--font-mono, monospace);
+  font-weight: 500;
+}
+.nb-group-body { padding: 0.4rem; }
+.nb-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.55rem 0.75rem;
+  border-radius: 5px;
+  text-decoration: none;
+  color: var(--foreground);
+  gap: 0.75rem;
+  transition: background 0.1s;
+}
+.nb-row:hover { background: var(--muted); }
+.nb-row-info  { flex: 1; min-width: 0; }
+.nb-row-name  {
+  font-size: 0.875rem;
+  font-weight: 500;
+  display: block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.nb-icon { margin-right: 0.3rem; }
+.nb-row-desc {
+  font-size: 0.72rem;
+  color: var(--muted-foreground);
+  display: block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-top: 0.1rem;
+  font-family: var(--font-mono, monospace);
+}
+.nb-row-arrow {
+  color: var(--muted-foreground);
+  font-size: 0.8rem;
+  flex-shrink: 0;
+  transition: color 0.1s, transform 0.1s;
+}
+.nb-row:hover .nb-row-arrow {
+  color: var(--primary, #58a6ff);
+  transform: translateX(2px);
+}
+
+@media (max-width: 640px) {
+  .stat-value { font-size: 1.4rem; }
+  .overview-header { flex-direction: column; }
+}
+</style>

--- a/site/src/components/OverviewContent.astro
+++ b/site/src/components/OverviewContent.astro
@@ -137,36 +137,20 @@ const displayDate = new Date(date + 'T12:00:00Z').toLocaleDateString('en-US', {
 const DATA_BASE = '/data';
 
 /**
- * Read columns from a parquet file using hyparquet.
- * Returns an object mapping column names to arrays of values.
+ * Read rows from a parquet file using hyparquet.
+ * Returns array of objects with column names as keys.
  */
-async function readParquetColumns(date, filename, columns) {
+async function readParquet(date, filename, columns) {
   const url = `${DATA_BASE}/${date}/${filename}`;
   const res = await fetch(url);
   if (!res.ok) throw new Error(`HTTP ${res.status}: ${url}`);
   const buffer = await res.arrayBuffer();
 
-  const { parquetRead } = await import('https://esm.sh/hyparquet@1.7.1');
+  const { parquetReadObjects } = await import(
+    'https://esm.sh/hyparquet'
+  );
 
-  return new Promise((resolve, reject) => {
-    try {
-      parquetRead({
-        file: buffer,
-        columns,
-        onComplete: (rows) => {
-          // rows is an array of arrays (one per row)
-          // Convert to column-oriented format
-          const out = {};
-          for (let ci = 0; ci < columns.length; ci++) {
-            out[columns[ci]] = rows.map(row => row[ci]);
-          }
-          resolve(out);
-        },
-      });
-    } catch (e) {
-      reject(e);
-    }
-  });
+  return await parquetReadObjects({ file: buffer, columns });
 }
 
 function setVal(id, text) {
@@ -184,8 +168,8 @@ function setColor(id, color) {
 
 async function loadBlobStats() {
   try {
-    const data = await readParquetColumns(date, 'blobs_per_slot.parquet', ['blob_count']);
-    const counts  = data['blob_count'];
+    const rows = await readParquet(date, 'blobs_per_slot.parquet', ['blob_count']);
+    const counts = rows.map(r => r.blob_count);
     const total   = counts.length;
     const missed  = counts.filter(v => v === 0 || v == null).length;
     const active  = counts.filter(v => v > 0);
@@ -217,21 +201,18 @@ async function loadBlobStats() {
 
 async function loadMempoolStats() {
   try {
-    // Try different possible column names
-    let data;
-    let col;
-    for (const colName of ['coverage_pct', 'visible_pct', 'coverage']) {
-      try {
-        data = await readParquetColumns(date, 'mempool_coverage.parquet', [colName]);
-        col = data[colName];
-        if (col && col.length > 0) break;
-      } catch { continue; }
-    }
-    if (!col || col.length === 0) throw new Error('no coverage column found');
+    const rows = await readParquet(
+      date, 'mempool_coverage.parquet',
+      ['total_txs', 'seen_in_mempool']
+    );
 
-    const values = col.filter(v => v != null).map(Number);
-    const avg    = values.reduce((a, b) => a + b, 0) / values.length;
-    const pct    = (avg > 1 ? avg : avg * 100).toFixed(1);
+    let totalTxs = 0;
+    let totalSeen = 0;
+    for (const r of rows) {
+      totalTxs  += Number(r.total_txs  || 0);
+      totalSeen += Number(r.seen_in_mempool || 0);
+    }
+    const pct = totalTxs > 0 ? ((totalSeen / totalTxs) * 100).toFixed(1) : '—';
 
     setVal('val-mempool', `${pct}%`);
     setSub('mempool', 'avg tx visibility pre-inclusion');

--- a/site/src/components/Sidebar.astro
+++ b/site/src/components/Sidebar.astro
@@ -28,6 +28,24 @@ const base = import.meta.env.BASE_URL;
       </span>
     </div>
     <ul class="m-0 flex list-none flex-col p-0">
+      <li>
+        <a
+          href={`${base}latest/overview`}
+          class:list={[
+            'group text-muted-foreground relative flex items-center gap-2 px-2 py-1.5 text-[0.8125rem] no-underline transition-all duration-200',
+            "before:bg-primary before:absolute before:top-1/2 before:left-0 before:h-0 before:w-[2px] before:-translate-y-1/2 before:transition-all before:duration-200 before:content-['']",
+            'hover:text-foreground hover:bg-muted hover:before:h-1/2',
+            currentPath.includes('/latest/overview') || currentPath === `${base}latest` || currentPath === `${base}latest/`
+              ? 'text-foreground bg-[var(--mauve-4)] font-medium before:!h-[60%]' : '',
+          ]}
+          title="Network health overview"
+        >
+          <span class="group-hover:text-primary group-[.active]:text-primary flex shrink-0 items-center justify-center opacity-50 transition-all duration-200 group-hover:opacity-100 group-[.active]:opacity-100">
+            <Icon name="LayoutDashboard" size={12} />
+          </span>
+          <span class="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap">Overview</span>
+        </a>
+      </li>
       {
         notebooks.map((nb, index) => {
           const href = `${base}latest/${nb.id}`;

--- a/site/src/components/ui/SidebarList.tsx
+++ b/site/src/components/ui/SidebarList.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { cn, toPathDate, formatShortDate } from '@/lib/utils';
-import { FileText, Calendar, Download } from 'lucide-react';
+import { FileText, Calendar, Download, LayoutDashboard } from 'lucide-react';
 
 interface Notebook {
   id: string;
@@ -31,6 +31,24 @@ export function SidebarList({ notebooks, latestDate, historicalDates, currentPat
           </span>
         </div>
         <ul className="m-0 flex list-none flex-col p-0">
+          <li key="overview">
+            <a
+              href={`${base}latest/overview`}
+              className={cn(
+                'group text-muted-foreground relative flex items-center gap-2 px-2 py-1.5 text-[0.8125rem] no-underline transition-all duration-200',
+                "before:bg-primary before:absolute before:top-1/2 before:left-0 before:h-0 before:w-[2px] before:-translate-y-1/2 before:transition-all before:duration-200 before:content-['']",
+                'hover:text-foreground hover:bg-muted hover:before:h-1/2',
+                currentPath.includes('/latest/overview') || currentPath === `${base}latest` || currentPath === `${base}latest/`
+                  ? 'text-foreground bg-[var(--mauve-4)] font-medium before:!h-[60%]' : '',
+              )}
+              title="Network health overview"
+            >
+              <span className="group-hover:text-primary group-[.active]:text-primary flex shrink-0 items-center justify-center opacity-50 transition-all duration-200 group-hover:opacity-100 group-[.active]:opacity-100">
+                <LayoutDashboard size={12} />
+              </span>
+              <span className="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap">Overview</span>
+            </a>
+          </li>
           {notebooks.map((nb) => {
             const href = `${base}latest/${nb.id}`;
             const isActive = currentPath.includes(`/latest/${nb.id}`);

--- a/site/src/pages/[year]/[month]/[day]/overview.astro
+++ b/site/src/pages/[year]/[month]/[day]/overview.astro
@@ -1,0 +1,35 @@
+---
+import BaseLayout from '@/layouts/BaseLayout.astro';
+import DateNav from '@/components/DateNav.astro';
+import OverviewContent from '@/components/OverviewContent.astro';
+import { getAvailableDates, getNotebooks, getManifest } from '@/lib/data';
+
+export function getStaticPaths() {
+  const manifest = getManifest();
+  const paths: Array<{
+    params: { year: string; month: string; day: string };
+    props: { isoDate: string };
+  }> = [];
+
+  for (const isoDate of Object.keys(manifest.dates || {})) {
+    const [year, month, day] = isoDate.split('-');
+    paths.push({ params: { year, month, day }, props: { isoDate } });
+  }
+  return paths;
+}
+
+const { year, month, day } = Astro.params;
+const { isoDate } = Astro.props;
+
+const dateIso = isoDate || `${year}-${month}-${day}`;
+const availableDates = getAvailableDates();
+const notebooks = getNotebooks();
+---
+
+<BaseLayout
+  title={`Overview — ${dateIso}`}
+  description={`Network health summary for ${dateIso}`}
+>
+  <DateNav slot="header" currentDate={dateIso} notebookId="overview" availableDates={availableDates} />
+  <OverviewContent date={dateIso} notebooks={notebooks} />
+</BaseLayout>

--- a/site/src/pages/latest/overview.astro
+++ b/site/src/pages/latest/overview.astro
@@ -1,0 +1,15 @@
+---
+import BaseLayout from '@/layouts/BaseLayout.astro';
+import DateNav from '@/components/DateNav.astro';
+import OverviewContent from '@/components/OverviewContent.astro';
+import { getLatestDate, getAvailableDates, getNotebooks } from '@/lib/data';
+
+const latestDate = getLatestDate();
+const availableDates = getAvailableDates();
+const notebooks = getNotebooks();
+---
+
+<BaseLayout title="Overview" description="Network health summary for the Ethereum P2P Observatory">
+  <DateNav slot="header" currentDate={latestDate} notebookId="overview" availableDates={availableDates} />
+  <OverviewContent date={latestDate} notebooks={notebooks} />
+</BaseLayout>


### PR DESCRIPTION
## What

Adds an overview dashboard page at `/latest/overview` and `/[year]/[month]/[day]/overview` that surfaces key network health metrics (avg blobs/slot, missed slots, mempool coverage) with drill-down links to individual notebooks.

## Changes

- **OverviewContent.astro** — stat cards with client-side parquet loading via hyparquet (pure JS, no WASM), notebook grid grouped by category
- **latest/overview.astro** + **[year]/[month]/[day]/overview.astro** — page routes
- **Sidebar.astro** + **SidebarList.tsx** — Overview link in desktop and mobile nav
- **Icon.astro** — added LayoutDashboard icon

## Notes

- Uses `hyparquet` instead of `parquet-wasm` to avoid WASM initialization issues in browsers
- Stat cards degrade gracefully when data is unavailable
- This is an Astro UI addition, separate from the Jupyter-based `feat/network-overview` branch